### PR TITLE
Add `password` and `openstack-dev` charts

### DIFF
--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -1,0 +1,9 @@
+chart-dirs:
+  - charts
+check-version-increment: true
+debug: true
+remote: origin
+target-branch: main
+validate-chart-schema: true
+validate-maintainers: true
+validate-yaml: true

--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -1,0 +1,65 @@
+name: Generate Chart Readme
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'charts/**/values.yaml'
+env:
+  RUN_README: 1
+
+jobs:
+  generate-chart-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout kungze/readme-generator-for-helm
+        uses: actions/checkout@v2
+        with:
+          repository: 'kungze/readme-generator-for-helm'
+          ref: 'kungze'
+          path: readme-generator-for-helm
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('readme-generator-for-helm/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+      - name: Install readme-generator-for-helm dependencies
+        run: cd readme-generator-for-helm && npm install
+
+      - name: Checkout kolla-helm/charts
+        uses: actions/checkout@v2
+        with:
+          path: charts
+
+      - name: Get list of files with changes in Pull Request
+        id: pr-file-changes
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          fileOutput: ' '
+
+      - name: Prepare readme-generator-for-helm inputs
+        run: |
+          cat $HOME/files.txt | tr " " "\n" | grep \/values\\.yaml > raw-inputs
+          cat raw-inputs | sed 's/values.yaml/README.md/' >> raw-inputs
+          cat raw-inputs | sed 's/charts/charts\/charts/' > prepared-inputs
+          echo `cat prepared-inputs |grep README | wc -l` >> $RUN_README
+
+      - name: Execute readme-generator-for-helm
+        if: ${{ env.RUN_README == 1 }}
+        run: readme-generator-for-helm/bin/index.js -v $(cat prepared-inputs | grep values) -r $(cat prepared-inputs | grep README) -s values.schema.json
+
+      - name: Output generated README.md
+        if: ${{ env.RUN_README == 1 }}
+        run: cat $(cat prepared-inputs | grep README)
+
+      - name: Output gererated values.schema.json
+        if: ${{ env.RUN_README == 1 }}
+        run: cat values.schema.json

--- a/.github/workflows/install-openstack-dep.yaml
+++ b/.github/workflows/install-openstack-dep.yaml
@@ -1,0 +1,33 @@
+name: Install openstack-dep chart
+
+on:
+  pull_request:
+    paths:
+      - 'charts/openstack-dep/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+
+      - name: Create k8s namespace
+        run:
+          kubectl create namespace openstack-dep
+
+      - name: Install password chart
+        run:
+          helm install openstack-password charts/password --namespace openstack-dep
+
+      - name: Run chart-testing (install)
+        run: ct install --namespace openstack-dep --target-branch main --charts charts/openstack-dep --debug

--- a/.github/workflows/install-password.yaml
+++ b/.github/workflows/install-password.yaml
@@ -1,0 +1,25 @@
+name: Install password Chart
+
+on:
+  pull_request:
+    paths:
+      - 'charts/password/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+
+      - name: Run chart-testing (install)
+        run: ct install --target-branch main --charts charts/password --debug

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,19 @@
+name: Lint Charts
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/ct-lint.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.tgz
+/.idea/*
+.vscode
+.DS_Store
+Chart.lock
+*.swp

--- a/charts/openstack-dep/Chart.yaml
+++ b/charts/openstack-dep/Chart.yaml
@@ -1,0 +1,36 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: v2
+description: Install openstack dependency service
+name: openstack-dep
+version: 1.0.0
+home: https://github.com/kungze/kolla-helm
+maintainers:
+  - name: Kungze
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
+  - condition: rabbitmq.enabled
+    name: rabbitmq
+    repository: https://charts.bitnami.com/bitnami
+    version: 8.x.x
+  - condition: memcached.enabled
+    name: memcached
+    repository: https://charts.bitnami.com/bitnami
+    version: 6.x.x
+  - condition: nginx-ingress-controller.enabled
+    name: nginx-ingress-controller
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x

--- a/charts/openstack-dep/README.md
+++ b/charts/openstack-dep/README.md
@@ -1,0 +1,99 @@
+# Install the common dependency services for openstack
+
+This chart will install [mariadb][mariadb], [rabbitmq][rabbitmq],
+[memcached][memcached], [nginx-ingress-controller][nginx-ingress-controller] etc,
+these are the dependency services of openstack projects. We wish all of openstack projects
+can share same dependency services release, so this chart should be installed before install any
+openstack projects.
+
+## TL;DR
+
+```base
+$ helm repo add kolla-helm https://kungze.github.io/kolla-helm
+$ helm install openstack-password kolla-helm/password
+$ helm install openstack-dependency kolla-helm/openstack-dep
+```
+
+**NOTE:** The dependent chart ``password`` need to be installed in advance. For details, please
+refer to the [docs](https://github.com/kungze/kolla-helm/blob/main/charts/password/README.md)
+
+The connection informations of these services will be save in a ``secret`` named with this chart
+release's name, like below:
+
+```yaml
+apiVersion: v1
+data:
+  database: b3BlbnN0YWNrLWRlcGVuZGVuY3ktbWFyaWFkYi50ZXN0LW9wZW5zdGFjay5zdmMuY2x1c3Rlci5sb2NhbDozMzA2
+  memcache: b3BlbnN0YWNrLWRlcGVuZGVuY3ktbWVtY2FjaGVkLnRlc3Qtb3BlbnN0YWNrLnN2Yy5jbHVzdGVyLmxvY2FsOjExMjEx
+  rabbitmq: b3BlbnN0YWNrLWRlcGVuZGVuY3ktcmFiYml0bXEudGVzdC1vcGVuc3RhY2suc3ZjLmNsdXN0ZXIubG9jYWw6NTY3Mg==
+kind: Secret
+metadata:
+  annotations:
+    meta.helm.sh/release-name: openstack-dependency
+    meta.helm.sh/release-namespace: test-openstack
+  creationTimestamp: "2022-04-22T06:37:55Z"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: openstack-dependency
+  namespace: default
+  resourceVersion: "12731688"
+  uid: 3450ccb0-e20f-4a2c-a2a1-9765038742c7
+type: Opaque
+```
+
+## Parameters
+
+### Global Parameters
+
+| Name                  | Form title           | Description                                    | Value           |
+| --------------------- | -------------------- | ---------------------------------------------- | --------------- |
+| `clusterDomainSuffix` | Cluser domain suffix | The domain suffix of of the current k8s cluser | `cluster.local` |
+
+
+### Database Parameters
+
+| Name                                         | Form title             | Description                                                                                           | Value                |
+| -------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- | -------------------- |
+| `mariadb.enabled`                            | Mariadb                | Whether or not deploy mariadb database                                                                | `true`               |
+| `mariadb.architecture`                       | Architecture           | MariaDB architecture (`standalone` or `replication`)                                                  | `standalone`         |
+| `mariadb.auth.existingSecret`                | Password chart release | Use the secret of the kolla-helm/charts/password release to provide the password for mariadb instance | `openstack-password` |
+| `mariadb.primary.persistence.storageClass`   | Primary Storage Class  | Persistent Volume storage class                                                                       | `""`                 |
+| `mariadb.primary.persistence.size`           | Primary Storage Size   | Persistent Volume size                                                                                | `8Gi`                |
+| `mariadb.secondary.replicaCount`             | Replica Number         | Number of MariaDB secondary replicas                                                                  | `1`                  |
+| `mariadb.secondary.persistence.storageClass` | Replica Storage Class  | MariaDB secondary persistent volume storage Class                                                     | `""`                 |
+| `mariadb.secondary.persistence.size`         | Replica Storage Size   | MariaDB secondary persistent volume size                                                              | `8Gi`                |
+
+
+### RabbitMQ parameters
+
+| Name                                   | Form title             | Description                                                                                            | Value                |
+| -------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ | -------------------- |
+| `rabbitmq.enabled`                     | Rabbitmq               | Whether or not deploy rabbitmq                                                                         | `true`               |
+| `rabbitmq.auth.username`               | Username               | RabbitMQ username                                                                                      | `openstack`          |
+| `rabbitmq.auth.existingPasswordSecret` | Password chart release | Use the secret of the kolla-helm/charts/password release to provide the password for rabbitmq instance | `openstack-password` |
+| `rabbitmq.persistence.storageClass`    | Storage Class          | Persistent Volume storage class                                                                        | `""`                 |
+| `rabbitmq.persistence.size`            | Storage Size           | Persistent Volume size                                                                                 | `8Gi`                |
+
+
+### Memcached parameters
+
+| Name                     | Form title | Description                     | Value   |
+| ------------------------ | ---------- | ------------------------------- | ------- |
+| `memcached.enabled`      | Memcached  | Whether or not deploy memcached | `true`  |
+| `memcached.service.port` |            | Memcached service port          | `11211` |
+
+
+### Nginx-ingress-controller  parameters
+
+| Name                                                   | Form title               | Description                                                                      | Value       |
+| ------------------------------------------------------ | ------------------------ | -------------------------------------------------------------------------------- | ----------- |
+| `nginx-ingress-controller.enabled`                     | Nginx-ingress-controller | Whether or not deploy nginx-ingress-controller                                   | `true`      |
+| `nginx-ingress-controller.defaultBackend.service.type` |                          | Kubernetes Service type for default backend                                      | `ClusterIP` |
+| `nginx-ingress-controller.kind`                        |                          | Install as DaemonSet                                                             | `DaemonSet` |
+| `nginx-ingress-controller.daemonset.useHostPort`       |                          | If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443` | `true`      |
+
+
+[mariadb]: https://github.com/bitnami/charts/tree/master/bitnami/mariadb
+[rabbitmq]: https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq
+[memcached]: https://github.com/bitnami/charts/tree/master/bitnami/memcached
+[nginx-ingress-controller]: https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller

--- a/charts/openstack-dep/templates/NOTES.txt
+++ b/charts/openstack-dep/templates/NOTES.txt
@@ -1,0 +1,34 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+
+** Please be patient while the chart is being deployed **
+
+Check these services's connection informations secret:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }} -o yaml
+
+Get mariadb connection address:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }} -o jsonpath="{.data.DATABASE}" | base64 -d
+
+Get rabbitmq connection address:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }} -o jsonpath="{.data.RABBITMQ}" | base64 -d
+
+Get memcached connection address:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }} -o jsonpath="{.data.MEMCACHE}" | base64 -d

--- a/charts/openstack-dep/templates/_helpers.tpl
+++ b/charts/openstack-dep/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name for RabbitMQ subchart
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "openstack.rabbitmq.fullname" -}}
+{{- if .Values.rabbitmq.fullnameOverride -}}
+{{- .Values.rabbitmq.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "rabbitmq" .Values.rabbitmq.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the RabbitMQ host
+*/}}
+{{- define "openstack.rabbitmqHost" -}}
+    {{- $releaseNamespace := .Release.Namespace }}
+    {{- $clusterDomain := .Values.clusterDomainSuffix }}
+    {{- printf "%s.%s.svc.%s" (include "openstack.rabbitmq.fullname" .) $releaseNamespace $clusterDomain -}}
+{{- end -}}
+
+{{/*
+Return the RabbitMQ port
+*/}}
+{{- define "openstack.rabbitmqPort" -}}
+    {{- printf "%d" (.Values.rabbitmq.service.port | int ) -}}
+{{- end -}}
+
+{{/*
+Return the proper Keystone image name
+*/}}
+{{- define "rabbitmq.connInfo" -}}
+    {{- $rabbitmqHost := include "openstack.rabbitmqHost" . }}
+    {{- $rabbitmqPort := (include "openstack.rabbitmqPort" . | int) }}
+    {{- printf "%s:%d" $rabbitmqHost $rabbitmqPort }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "openstack.database.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the Database host
+*/}}
+{{- define "openstack.databaseHost" -}}
+    {{- $releaseNamespace := .Release.Namespace }}
+    {{- $clusterDomain := .Values.clusterDomainSuffix }}
+    {{- printf "%s.%s.svc.%s" (include "openstack.database.fullname" .) $releaseNamespace $clusterDomain -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Port
+*/}}
+{{- define "openstack.databasePort" -}}
+    {{- printf "3306" -}}
+{{- end -}}
+
+{{/*
+Return the database connInfo
+*/}}
+{{- define "database.connInfo" -}}
+    {{- $databaseHost := include "openstack.databaseHost" . }}
+    {{- $databasePort := (include "openstack.databasePort" . | int) }}
+    {{- printf "%s:%d" $databaseHost $databasePort }}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "openstack.memcached.fullname" -}}
+{{- printf "%s-%s" .Release.Name "memcached" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the Memcached Hostname
+*/}}
+{{- define "openstack.cacheHost" -}}
+    {{- $releaseNamespace := .Release.Namespace }}
+    {{- $clusterDomain := .Values.clusterDomainSuffix }}
+    {{- printf "%s.%s.svc.%s" (include "openstack.memcached.fullname" .) $releaseNamespace $clusterDomain -}}
+{{- end -}}
+
+{{/*
+Return the Memcached Port
+*/}}
+{{- define "openstack.cachePort" -}}
+    {{- printf "11211" -}}
+{{- end -}}
+
+{{/*
+Return the memcached connInfo
+*/}}
+{{- define "memcached.connInfo" -}}
+    {{- $memcachedHost := include "openstack.cacheHost" . }}
+    {{- $memcachedPort := (include "openstack.cachePort" . | int) }}
+    {{- printf "%s:%d" $memcachedHost $memcachedPort }}
+{{- end -}}

--- a/charts/openstack-dep/templates/secrets.yaml
+++ b/charts/openstack-dep/templates/secrets.yaml
@@ -1,0 +1,30 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+type: Opaque
+data:
+  {{- if .Values.rabbitmq.enabled }}
+  RABBITMQ: {{ include "rabbitmq.connInfo" . | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.mariadb.enabled }}
+  DATABASE: {{ include "database.connInfo" . | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.memcached.enabled }}
+  MEMCACHE: {{ include "memcached.connInfo" . | b64enc | quote }}
+  {{- end }}

--- a/charts/openstack-dep/values.schema.json
+++ b/charts/openstack-dep/values.schema.json
@@ -1,0 +1,217 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "clusterDomainSuffix": {
+            "form": true,
+            "type": "string",
+            "description": "The domain suffix of of the current k8s cluser",
+            "title": "Cluser domain suffix",
+            "default": "cluster.local"
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "form": true,
+                    "type": "boolean",
+                    "description": "Whether or not deploy mariadb database",
+                    "title": "Mariadb",
+                    "default": true
+                },
+                "architecture": {
+                    "form": true,
+                    "type": "string",
+                    "description": "MariaDB architecture (`standalone` or `replication`)",
+                    "title": "Architecture",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "existingSecret": {
+                            "form": true,
+                            "type": "string",
+                            "description": "Use the secret of the kolla-helm/charts/password release to provide the password for mariadb instance",
+                            "title": "Password chart release",
+                            "default": "openstack-password"
+                        }
+                    }
+                },
+                "primary": {
+                    "type": "object",
+                    "properties": {
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "storageClass": {
+                                    "form": true,
+                                    "type": "string",
+                                    "description": "Persistent Volume storage class",
+                                    "title": "Primary Storage Class",
+                                    "default": ""
+                                },
+                                "size": {
+                                    "form": true,
+                                    "type": "string",
+                                    "description": "Persistent Volume size",
+                                    "title": "Primary Storage Size",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                },
+                "secondary": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "form": true,
+                            "type": "number",
+                            "description": "Number of MariaDB secondary replicas",
+                            "title": "Replica Number",
+                            "default": 1
+                        },
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "storageClass": {
+                                    "form": true,
+                                    "type": "string",
+                                    "description": "MariaDB secondary persistent volume storage Class",
+                                    "title": "Replica Storage Class",
+                                    "default": ""
+                                },
+                                "size": {
+                                    "form": true,
+                                    "type": "string",
+                                    "description": "MariaDB secondary persistent volume size",
+                                    "title": "Replica Storage Size",
+                                    "default": "8Gi"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "rabbitmq": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "form": true,
+                    "type": "boolean",
+                    "description": "Whether or not deploy rabbitmq",
+                    "title": "Rabbitmq",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "form": true,
+                            "type": "string",
+                            "description": "RabbitMQ username",
+                            "title": "Username",
+                            "default": "openstack"
+                        },
+                        "existingPasswordSecret": {
+                            "form": true,
+                            "type": "string",
+                            "description": "Use the secret of the kolla-helm/charts/password release to provide the password for rabbitmq instance",
+                            "title": "Password chart release",
+                            "default": "openstack-password"
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "storageClass": {
+                            "form": true,
+                            "type": "string",
+                            "description": "Persistent Volume storage class",
+                            "title": "Storage Class",
+                            "default": ""
+                        },
+                        "size": {
+                            "form": true,
+                            "type": "string",
+                            "description": "Persistent Volume size",
+                            "title": "Storage Size",
+                            "default": "8Gi"
+                        }
+                    }
+                }
+            }
+        },
+        "memcached": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "form": true,
+                    "type": "boolean",
+                    "description": "Whether or not deploy memcached",
+                    "title": "Memcached",
+                    "default": true
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "form": true,
+                            "type": "number",
+                            "description": "Memcached service port",
+                            "default": 11211
+                        }
+                    }
+                }
+            }
+        },
+        "nginx-ingress-controller": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "form": true,
+                    "type": "boolean",
+                    "description": "Whether or not deploy nginx-ingress-controller",
+                    "title": "Nginx-ingress-controller",
+                    "default": true
+                },
+                "defaultBackend": {
+                    "type": "object",
+                    "properties": {
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "form": true,
+                                    "type": "string",
+                                    "description": "Kubernetes Service type for default backend",
+                                    "default": "ClusterIP"
+                                }
+                            }
+                        }
+                    }
+                },
+                "kind": {
+                    "form": true,
+                    "type": "string",
+                    "description": "Install as DaemonSet",
+                    "default": "DaemonSet"
+                },
+                "daemonset": {
+                    "type": "object",
+                    "properties": {
+                        "useHostPort": {
+                            "form": true,
+                            "type": "boolean",
+                            "description": "If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/openstack-dep/values.yaml
+++ b/charts/openstack-dep/values.yaml
@@ -1,0 +1,112 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+## @section Global Parameters
+## @param clusterDomainSuffix [t#Cluser domain suffix] The domain suffix of of the current k8s cluser
+clusterDomainSuffix: cluster.local
+
+## @section Database Parameters
+## MariaDB chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
+mariadb:
+  ## @param mariadb.enabled [t#Mariadb] Whether or not deploy mariadb database
+  enabled: true
+  ## @param mariadb.architecture [t#Architecture] MariaDB architecture (`standalone` or `replication`)
+  architecture: standalone
+  ## @param mariadb.auth.existingSecret [t#Password chart release] Use the secret of the kolla-helm/charts/password release to provide the password for mariadb instance
+  auth:
+    existingSecret: openstack-password
+  ## MariaDB Primary configuration
+  primary:
+    ## MariaDB Primary Persistence parameters
+    ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+    ## @param mariadb.primary.persistence.storageClass [t#Primary Storage Class] Persistent Volume storage class
+    ## @param mariadb.primary.persistence.size [t#Primary Storage Size] Persistent Volume size
+    ## @skip mariadb.primary.persistence.enabled
+    ## @skip mariadb.primary.persistence.accessModes
+    persistence:
+      storageClass: ""
+      size: 8Gi
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+  ## MariaDB Secondary configuration
+  secondary:
+    ## @param mariadb.secondary.replicaCount [t#Replica Number] Number of MariaDB secondary replicas
+    replicaCount: 1
+    ## @param mariadb.secondary.persistence.storageClass [t#Replica Storage Class] MariaDB secondary persistent volume storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    ## @param mariadb.secondary.persistence.size [t#Replica Storage Size] MariaDB secondary persistent volume size
+    ## @skip mariadb.secondary.persistence.enabled
+    ## @skip mariadb.secondary.persistence.accessModes
+    persistence:
+      storageClass: ""
+      size: 8Gi
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+
+## @section RabbitMQ parameters
+## RabbitMQ chart configuration
+## https://github.com/bitnami/charts/blob/master/bitnami/rabbitmq/values.yaml
+rabbitmq:
+  ## @param rabbitmq.enabled [t#Rabbitmq] Whether or not deploy rabbitmq
+  enabled: true
+  ## @param rabbitmq.auth.username [t#Username] RabbitMQ username
+  ## @param rabbitmq.auth.existingPasswordSecret [t#Password chart release] Use the secret of the kolla-helm/charts/password release to provide the password for rabbitmq instance
+  auth:
+    username: openstack
+    existingPasswordSecret: openstack-password
+  ## @param rabbitmq.persistence.storageClass [t#Storage Class] Persistent Volume storage class
+  ## @param rabbitmq.persistence.size [t#Storage Size] Persistent Volume size
+  ## @skip rabbitmq.persistence.enabled
+  ## @skip rabbitmq.persistence.accessModes
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: 8Gi
+    accessModes:
+      - ReadWriteOnce
+
+## @section Memcached parameters
+## Memcached chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/memcached/values.yaml
+memcached:
+  ## @param memcached.enabled [t#Memcached] Whether or not deploy memcached
+  enabled: true
+  ## Service parameters
+  service:
+    ## @param memcached.service.port Memcached service port
+    port: 11211
+
+## @section Nginx-ingress-controller  parameters
+## nginx-ingress-controller chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+nginx-ingress-controller:
+  ## @param nginx-ingress-controller.enabled [t#Nginx-ingress-controller] Whether or not deploy nginx-ingress-controller
+  enabled: true
+  ## @param nginx-ingress-controller.service.type Kubernetes Service type for default backend
+  service:
+    type: ClusterIP
+  ## @skip nginx-ingress-controller.podLabels
+  podLabels:
+    app: ingress-api
+  ## @param nginx-ingress-controller.kind Install as DaemonSet
+  kind: DaemonSet
+  ## @param nginx-ingress-controller.daemonset.useHostPort If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`
+  daemonset:
+    useHostPort: true

--- a/charts/password/Chart.yaml
+++ b/charts/password/Chart.yaml
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+description: Automatically generate random password for openstack relate projects
+name: password
+version: 1.0.0
+home: https://github.com/kungze/kolla-helm
+maintainers:
+  - name: Kungze

--- a/charts/password/README.md
+++ b/charts/password/README.md
@@ -1,0 +1,45 @@
+# Automatically Generate Openstack Related Passwords
+
+Randomly generate necessary passwords which used by openstack and openstack dependency project.
+These passwords save in a ``secret``, the ``secret`` name same as the helm ``release`` name. These
+password can be used by subsequent charts directly.
+
+**NOTE:** We want all of other charts can share a same ``password` chart release
+(we don't want each chart release to have a separate ``password`` release). So, we
+haven't straightforward dependency declaration in other charts about this chart. So,
+this chart need be installed before install other chart.
+
+## TL;DR
+
+```bash
+$ helm repo add kolla-helm https://kungze.github.io/kolla-helm
+$ helm install openstack-password kolla-helm/password
+```
+
+This will generate a ``secret`` named ``openstack-password``, like below:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "openstack-password"
+  namespace: "default"
+type: Opaque
+data:
+  mariadb-root-password:  "Q3R0dnBaTHVVdQ=="
+  keystone-admin-password: "VGltUjl0NmJHNw=="
+  keystone-database-password: "MnBLVUZBUzNCbg=="
+  glance-database-password: "bzU4dW53S0NiMg=="
+  glance-keystone-password: "MkRWeWxvS2RlQw=="
+  cinder-database-password: "NkpTaHZyak84eA=="
+  cinder-keystone-password: "aEhFc0IzZ2tNdw=="
+  neutron-keystone-password: "QXo1N0xzeVZJTg=="
+  neutron-database-password: "Y1YwaWY4VHQ5bg=="
+  nova-database-password: "QjV0OEtnRnY5aA=="
+  nova-keystone-password: "Q0hyZkxyaVNOMA=="
+  placement-database-password: "YXFMZ0V6SEZJeg=="
+  placement-keystone-password: "RzBXcm9vZDdSdw=="
+  rabbitmq-password: "ZFpkSUVCV3hXcg=="
+  rbd-secret-uuid: "NTAyZWRmYTgtNDgxOS00ODAxLTlhYjgtYmZmZDFmOGViNGEy"
+  cinder-rbd-secret-uuid: "N2ZkMWE4ODYtYTU0OC00MmY0LTk4OGEtNzU3YTZmNGY3MDc4"
+```

--- a/charts/password/templates/NOTES.txt
+++ b/charts/password/templates/NOTES.txt
@@ -1,0 +1,22 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and 
+limitations under the License.
+*/}}
+
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+
+** Please be patient while the chart is being deployed **
+
+Check the Secret:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }} -o yaml

--- a/charts/password/templates/secrets.yaml
+++ b/charts/password/templates/secrets.yaml
@@ -1,0 +1,39 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+type: Opaque
+data:
+  mariadb-root-password:  {{ randAlphaNum 10 | b64enc | quote }}
+  mariadb-replication-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mariadb-password: {{ randAlphaNum 10 | b64enc | quote }}
+  keystone-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  keystone-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  glance-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  glance-keystone-password: {{ randAlphaNum 10 | b64enc | quote }}
+  cinder-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  cinder-keystone-password: {{ randAlphaNum 10 | b64enc | quote }}
+  neutron-keystone-password: {{ randAlphaNum 10 | b64enc | quote }}
+  neutron-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  nova-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  nova-keystone-password: {{ randAlphaNum 10 | b64enc | quote }}
+  placement-database-password: {{ randAlphaNum 10 | b64enc | quote }}
+  placement-keystone-password: {{ randAlphaNum 10 | b64enc | quote }}
+  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  rbd-secret-uuid: {{ uuidv4 | b64enc | quote }}
+  cinder-rbd-secret-uuid: {{ uuidv4 | b64enc | quote }}

--- a/charts/password/values.yaml
+++ b/charts/password/values.yaml
@@ -1,0 +1,5 @@
+## kolla-helm/password
+## It is required by CI/CD tools and processes.
+## @skip exampleValue
+##
+exampleValue: password-chart


### PR DESCRIPTION
1. The `password` chart used to generate some random passwords, these
passwords can be used by subsequent openstack ant openstack related
projects.
2. The `openstack-dep` chart used to install the common dependency
components of openstack projects.