### PR TITLE
Solve some problems in common chart

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -13,7 +13,7 @@
 apiVersion: v2
 description: Openstack kolla helm common library
 name: common
-version: 1.0.4
+version: 1.0.5
 home: https://github.com/kungze/kolla-helm
 maintainers:
   - name: Kungze

--- a/charts/common/templates/manifests/_ingress-api.tpl
+++ b/charts/common/templates/manifests/_ingress-api.tpl
@@ -9,6 +9,9 @@ metadata:
   namespace: {{ $envAll.Release.Namespace | quote }}
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:
   ingressClassName: {{ $envAll.Values.ingress.ingressClass }}
   rules:

--- a/charts/common/templates/scripts/_gen_ceph_conf.sh.tpl
+++ b/charts/common/templates/scripts/_gen_ceph_conf.sh.tpl
@@ -3,7 +3,7 @@
 
 CEPH_CONFIG="/etc/ceph/ceph.conf"
 MON_CONFIG="/etc/rook/mon-endpoints"
-KEYRING_FILE="/etc/ceph/keyring"
+KEYRING_FILE="/etc/ceph/ceph.client.$ROOK_CEPH_USERNAME.keyring"
 
 # create a ceph config file in its default location so ceph/rados tools can be used
 # without specifying any arguments


### PR DESCRIPTION
1. Solve the error when uploading the big image:
   413 Request Entity Too Large: nginx
2. Change keyring file name in _gen_ceph_conf.sh.tpl, Because
   openstack specifies that the format of the file name is:
   'ceph.client.$ROOK_CEPH_USERNAME.keyring'