### PR TITLE
Fix bug in sync-ceph-endpoint

### DIFF
--- a/charts/openstack-dep/Chart.yaml
+++ b/charts/openstack-dep/Chart.yaml
@@ -13,7 +13,7 @@
 apiVersion: v2
 description: Install openstack dependency service
 name: openstack-dep
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/kungze/kolla-helm
 maintainers:
   - name: Kungze

--- a/charts/openstack-dep/templates/bin/_sync-ceph-endpoint.py.tpl
+++ b/charts/openstack-dep/templates/bin/_sync-ceph-endpoint.py.tpl
@@ -9,7 +9,6 @@ KUBE_CERT = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 KUBE_TOKEN = None
 NAMESPACE = os.environ['KUBERNETES_NAMESPACE']
 ROOK_CEPH_CLUSTER_NAMESPACE = os.getenv('ROOK_CEPH_CLUSTER_NAMESPACE', None)
-ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP = os.getenv('ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP', None)
 OS_CEPH_MON_CONFIGMAP = os.getenv('OS_CEPH_MON_CONFIGMAP', None)
 
 LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
@@ -75,7 +74,7 @@ def update_configmap(configmap):
 
 def main():
     read_kube_config()
-    rook_cm = get_rook_configmap(ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP)
+    rook_cm = get_rook_configmap('rook-ceph-mon-endpoints')
 
     self_cm = get_self_configmap(OS_CEPH_MON_CONFIGMAP)
     self_cm['data'] = rook_cm['data']

--- a/charts/openstack-dep/templates/job-sync-rook-ceph-endpoint.yaml
+++ b/charts/openstack-dep/templates/job-sync-rook-ceph-endpoint.yaml
@@ -21,8 +21,6 @@ spec:
               value: {{ .Release.Namespace }}
             - name: ROOK_CEPH_CLUSTER_NAMESPACE
               value: {{ .Values.ceph.cephClusterNamespace }}
-            - name: ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP
-              value:  {{ printf "%s-mon-endpoints" .Values.ceph.cephClusterName }}
             - name: OS_CEPH_MON_CONFIGMAP
               value: "ceph-monitor-endpoints"
           volumeMounts:


### PR DESCRIPTION
In sync-ceph-endpoint, remove the variable 'ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP'
and change it to the fixed value 'rook-ceph-mon-endpoints'.